### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ cscope.out.temp
 tags
 tags.lock
 tags.temp
+.vscode
 
 
 # Zepyhr / nRF5 SDK stuff
@@ -13,6 +14,8 @@ compile_commands.json
 .cache
 **/build/*
 build/*
+build*
+generated
 
 # Python stuff
 __pycache__
@@ -36,3 +39,6 @@ wheels/
 share/python-wheels/
 *.egg-info/
 *.egg
+
+#envrc
+.envrc


### PR DESCRIPTION
`.vscode` - the vscode folder. Im most unsure about this one since for some files in vscode folder you might want to allow them. But I would still add this and then allow a specific file to be added, rather then the other way around. `build*` - also ignore folders and files like `build91`, `build_nrf52`, `build_wifi_nrf52_debug`, ... `generated` - Used in your version info lib.
`.envrc` - envrc file