### PR TITLE
fix(CI): Release action changelog update commit is now conventional

### DIFF
--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -52,7 +52,7 @@ jobs:
       - name: Commit Changelog, create tag and push
         run: |
           git add CHANGELOG.md
-          git commit -m "Update CHANGELOG.md for Release ${{ inputs.version }}"
+          git commit -m "docs: Update CHANGELOG.md for release ${{ inputs.version }}"
           git tag ${{ inputs.version }}
           git push
           git push origin ${{ inputs.version }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -85,7 +85,7 @@ repos:
   - repo: https://github.com/igorshubovych/markdownlint-cli
     rev: v0.42.0
     hooks:
-      - id: markdownlint
+      - id: markdownlint-docker
         exclude: CHANGELOG.md
         args: [--fix]
         stages: [pre-commit]

--- a/README.md
+++ b/README.md
@@ -55,9 +55,9 @@ of CI workflows for release automation.
 
 ## Repository folder structure
 
-- `doc/` - Project and development documentation.
-- `doc/images/` - Images used in the documentation, such as diagrams, screenshots, or logos.
-- `assets/` - Files that will be part of the next release. process.
+- `docs/` - Project and development documentation.
+- `docs/images/` - Images used in the documentation, such as diagrams, screenshots, or logos.
+- `assets/` - Files that will be part of the next release process.
 - `CHANGELOG.md` - Document used for tracking changes in the project. It follows the
   [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) format.
 - `.github` - GitHub Actions workflows and other GitHub related files.


### PR DESCRIPTION
# Description

The release action makes a commit to the `main` branch to update the `CHANGELOG.md` file.
The commit message is now `docs: Update CHANGELOG.md for release vX.Y.Z`.

## Areas of interest for the reviewer

All

## Checklist

<!--- Check items that you fulfilled, strikeout the ones that do not apply and
write why  -->

- [x] My code follows the [style guidelines] as defined by IRNAS.
- [x] I have performed a self-review of my code.
- [x] My changes generate no new warnings.
- [x] I added/updated source code documentation for all newly added or changed functions.
- [x] ~~I updated all customer-facing technical documentation.~~ - This PR
      introduced only internal facing changes.

## After-review steps

<!--- Delete section or select one option -->

- I will merge PR by myself.

[style guidelines]: https://github.com/IRNAS/irnas-guidelines-docs/blob/main/docs/developer_guidelines.md
