### PR TITLE
fix(CI): Fix PR labeler sometimes failing

### DIFF
--- a/.github/workflows/label_pr.yaml
+++ b/.github/workflows/label_pr.yaml
@@ -11,6 +11,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
+      issues: write
     runs-on: ubuntu-latest
     steps:
       - uses: TimonVS/pr-labeler-action@v5.0.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -85,7 +85,7 @@ repos:
   - repo: https://github.com/igorshubovych/markdownlint-cli
     rev: v0.42.0
     hooks:
-      - id: markdownlint
+      - id: markdownlint-docker
         exclude: CHANGELOG.md
         args: [--fix]
         stages: [pre-commit]

--- a/README.md
+++ b/README.md
@@ -55,9 +55,9 @@ of CI workflows for release automation.
 
 ## Repository folder structure
 
-- `doc/` - Project and development documentation.
-- `doc/images/` - Images used in the documentation, such as diagrams, screenshots, or logos.
-- `assets/` - Files that will be part of the next release. process.
+- `docs/` - Project and development documentation.
+- `docs/images/` - Images used in the documentation, such as diagrams, screenshots, or logos.
+- `assets/` - Files that will be part of the next release process.
 - `CHANGELOG.md` - Document used for tracking changes in the project. It follows the
   [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) format.
 - `.github` - GitHub Actions workflows and other GitHub related files.


### PR DESCRIPTION
Prevent PR labeler action from failing sometimes, by also giving it the `issues:write` permission.

See [PR labeler repo](https://github.com/actions/labeler/issues/870) issue for details.