### PR TITLE
feat: add scripts and documentation for managing electronic projects

### DIFF
--- a/docs/development/electronic_projects.md
+++ b/docs/development/electronic_projects.md
@@ -1,0 +1,41 @@
+# Managing electronic projects
+
+At IRNAS the electronic projects are created and developed in Altium designer. GitHub repositories
+are used only provide a copy of the Altium project, to make this work accessible to external clients
+and to make possible handover easier.
+
+Although Altium Designer uses Git to version control project files, it doesn't have a direct GitHub
+integration. This requires some custom scripts to make syncing changes to GitHub and creating GitHub
+release a seamless experience.
+
+## Setup for running scripts
+
+The folder `scripts/electronics` contains all scripts that an electronic engineer would need.
+
+To run them you will need to install Git: <https://git-scm.com/downloads>
+
+After installing Git the scripts can be run by directly clicking on them or by running them in the
+`cmd` or Git Bash.
+
+## Creating a new Altium project
+
+TODO: below section needs more steps
+
+1. Create a new Altium project directly in the Altium Designer, from the provided template.
+2. Go through the project setup checklist and do it.
+3. Commit project changes in the Altium Designer.
+4. Run script `scripts/electronics/sync_to_github.sh`.
+
+Script will create a new GitHub repository with the same name as the Altium Project.
+
+## Syncing new Altium changes to the GitHub
+
+Whenever you need to sync recent Altium changes to the GitHub, without necessarily creating a new
+release, just run `script/electronics/sync_to_github.sh`
+
+## Creating a new release
+
+TODO:
+
+1. Create release through the Altium Designer.
+2. Run the script `scripts/electronics/create_release.sh`.

--- a/scripts/electronics/common.sh
+++ b/scripts/electronics/common.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+
+# Set the GitHub owner and host here.
+OWNER="MarkoSagadin"
+HOST="github.com"
+
+# Color codes
+export RED='\033[0;31m'
+export GREEN='\033[0;32m'
+export YELLOW='\033[1;33m'
+export BLUE='\033[0;34m'
+export NC='\033[0m' # No Color
+
+BANNER="###########################################################"
+
+# Determine script location and repo root
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+REPO_PATH="$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel)"
+REPO=$(basename "$REPO_PATH")
+export REPO_URL="https://$HOST/$OWNER/$REPO"
+
+# Since the project is first created by Altium, it's remote repo uses the
+# default "origin" name.
+export ALTIUM_ORIGIN="origin"
+# For the GitHub origin we choose a slightly different name.
+export GITHUB_ORIGIN="gh_origin"
+
+check_git() {
+    # Abort if git is not installed
+    if ! command -v git &>/dev/null; then
+        echo -e "${RED}ERROR: git is not installed.${NC}"
+        echo "Install it from: https://git-scm.com/downloads"
+        exit 1
+    fi
+    echo -e "git: ${GREEN}installed${NC}"
+}
+
+check_gh() {
+    # Abort if gh (GitHub CLI) is not installed
+    if ! command -v gh &>/dev/null; then
+        echo -e "${RED}ERROR: GitHub CLI tool (gh) is not installed.${NC}"
+        echo "Install it from: https://cli.github.com/"
+        exit 1
+    fi
+    echo -e "gh: ${GREEN}installed${NC}"
+}
+
+check_gh_auth() {
+    # Check if gh is authenticated, if not do it.
+    if ! gh auth status &>/dev/null; then
+        echo "${BANNER}"
+        echo -e "${YELLOW}WARN: No GitHub authentication detected, follow the instructions!${NC}"
+        echo -e "${YELLOW}Press Y key for the first question.${NC}"
+        echo "${BANNER}"
+        gh auth login --hostname "$HOST" --git-protocol https --web
+        echo "${BANNER}"
+        echo -e "${GREEN}Authentication completed, continuing!${NC}"
+        echo "${BANNER}"
+    fi
+    echo -e "GitHub account: ${GREEN}authenticated${NC}"
+}
+
+log_inf() {
+    echo -e "${YELLOW}${1}${NC}"
+}
+
+press_to_exit() {
+    read -pr "Press any key to exit..."
+    exit 0
+}

--- a/scripts/electronics/create_release.sh
+++ b/scripts/electronics/create_release.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+
+# shellcheck disable=SC1091
+source "${SCRIPT_DIR}"/common.sh
+
+echo
+echo "${BANNER}"
+echo "           Create GitHub release script"
+echo "${BANNER}"
+echo
+
+check_git
+check_gh
+check_gh_auth
+echo
+
+VERSION="${1:-}"
+if [[ -z ${VERSION} ]]; then
+    read -rp "Enter the release version (format: v1.2.3): " VERSION
+fi
+
+if [[ ! ${VERSION} =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    echo -e "${RED}ERROR: Invalid version format. Use format: v1.2.3.${NC}"
+    press_to_exit
+fi
+
+OUTPUT_DIR="${REPO_PATH}/output"
+if [[ ! -d ${OUTPUT_DIR} || -z "$(ls -A "${OUTPUT_DIR}")" ]]; then
+    echo -e "${RED}ERROR: Output folder is missing or empty. Exiting.${NC}"
+    press_to_exit
+fi
+
+"${SCRIPT_DIR}/update_changelog.sh" "${VERSION}"
+
+echo
+log_inf "Creating a new commit with updated Changelog"
+cd "${REPO_PATH}"
+git add CHANGELOG.md
+git commit -m "docs: update CHANGELOG.md for release ${VERSION}"
+
+echo
+log_inf "Creating a tag"
+git tag "${VERSION}"
+
+echo
+log_inf "Pushing new commit and tag to Altium remote repo"
+git push "${ALTIUM_ORIGIN}" HEAD "${VERSION}"
+echo
+log_inf "Pushing new commit and tag to GitHub remote repo"
+git push "${GITHUB_ORIGIN}" HEAD "${VERSION}"
+
+RELEASE_NOTES=$(awk -v ver="${VERSION#v}" '
+  BEGIN { in_section=0 }
+  $0 ~ "^## \\[" ver "\\]" {
+    in_section=1; next
+  }
+  in_section && /^## \[/ { exit }
+  in_section { print }
+' "${REPO_PATH}/CHANGELOG.md")
+
+echo
+log_inf "Creating a GitHub release"
+gh release create "${VERSION}" --title "${VERSION}" --notes "${RELEASE_NOTES}"
+
+cd "${OUTPUT_DIR}"
+
+echo
+log_inf "Uploading files in ${OUTPUT_DIR} to the release."
+
+# shellcheck disable=SC2046
+gh release upload "${VERSION}" $(ls)
+
+echo
+echo -e "${GREEN}Release ${VERSION} was created successfully.${NC}"
+press_to_exit

--- a/scripts/electronics/push_to_github.sh
+++ b/scripts/electronics/push_to_github.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+
+# shellcheck disable=SC1091
+source "${SCRIPT_DIR}"/common.sh
+
+echo
+echo "${BANNER}"
+echo "           Sync Altium project to GitHub script"
+echo "${BANNER}"
+echo
+
+check_git
+check_gh
+check_gh_auth
+
+echo -e "Altium project: ${GREEN}${REPO}${NC}"
+echo
+
+# Check if the repo exists, if not create it
+log_inf "Checking for repo on GitHub..."
+if ! gh repo view "${OWNER}/${REPO}" &>/dev/null; then
+    echo "Repo not found, creating it"
+    gh repo create "${OWNER}/${REPO}" --private &>/dev/null
+    echo "Created new repo at: ${YELLOW}${REPO_URL}${NC}"
+else
+    echo -e "Found repo at: ${YELLOW}${REPO_URL}${NC}"
+fi
+echo
+
+log_inf "Pushing repo to GitHub"
+# Check first if the GITHUB_ORIGIN was added, then push
+if git -C "${REPO_PATH}" remote get-url "${GITHUB_ORIGIN}" &>/dev/null; then
+    git -C "${REPO_PATH}" remote set-url "${GITHUB_ORIGIN}" "${REPO_URL}".git
+else
+    git -C "${REPO_PATH}" remote add "${GITHUB_ORIGIN}" "${REPO_URL}".git
+fi
+git -C "${REPO_PATH}" push --force "${GITHUB_ORIGIN}" HEAD
+
+echo
+echo -e "${GREEN}Done!${NC}"
+press_to_exit

--- a/scripts/electronics/update_changelog.sh
+++ b/scripts/electronics/update_changelog.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+
+# shellcheck disable=SC1091
+source "${SCRIPT_DIR}"/common.sh
+
+echo
+log_inf "Updating Changelog"
+
+CHANGELOG="${REPO_PATH}/CHANGELOG.md"
+
+# Get the remote URL from gh_origin
+REMOTE_URL="$(git -C "${REPO_PATH}" remote get-url gh_origin 2>/dev/null || true)"
+if [[ -z ${REMOTE_URL} ]]; then
+    echo -e "${RED}Remote 'gh_origin' not found!${NC}"
+    press_to_exit
+fi
+
+# Normalize GitHub URL (handles git@ and https://)
+if [[ $REMOTE_URL =~ ^git@github.com:(.*)\.git$ ]]; then
+    GH_REPO="https://github.com/${BASH_REMATCH[1]}"
+elif [[ $REMOTE_URL =~ ^https://github.com/(.*)\.git$ ]]; then
+    GH_REPO="https://github.com/${BASH_REMATCH[1]}"
+else
+    echo -e "${RED}Unsupported remote URL format: ${REMOTE_URL}${NC}"
+    press_to_exit
+fi
+
+# Check if Unreleased section exists and is not empty
+UNRELEASED_CONTENT=$(awk '/## \[Unreleased\]/ {found=1; next} /^## \[/ {found=0} found {print}' "${CHANGELOG}")
+if [[ -z ${UNRELEASED_CONTENT} ]]; then
+    echo -e "${RED}Unreleased section is empty, exiting!${NC}"
+    press_to_exit
+fi
+
+# Get version from argument or prompt the user
+VERSION="${1:-}"
+if [[ -z ${VERSION} ]]; then
+    read -rp "Enter the new version (format: v1.2.3): " VERSION
+fi
+
+# Validate version string
+if [[ ! ${VERSION} =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    echo -e "${RED}Invalid version format. Use format: v1.2.3${NC}"
+    press_to_exit
+fi
+
+# Remove 'v' prefix for display in the changelog header
+VERSION_NO_V="${VERSION#v}"
+
+# Get today's date
+DATE="$(date +%Y-%m-%d)"
+
+# Get previous version from changelog
+PREV_VERSION=$(awk '/^## \[([0-9]+\.[0-9]+\.[0-9]+)\]/ {print gensub(/## \[([0-9]+\.[0-9]+\.[0-9]+)\].*/, "\\1", "g"); exit}' "${CHANGELOG}")
+
+# Insert new version entry
+awk -v ver="${VERSION_NO_V}" -v date="${DATE}" '
+    BEGIN {in_unreleased=0}
+    /^## \[Unreleased\]/ {
+        print;
+        print "";
+        print "## [" ver "] - " date;
+        in_unreleased=1;
+        next;
+    }
+    in_unreleased && /^## \[/ {
+        in_unreleased=0;
+    }
+    in_unreleased {
+        print;
+        next;
+    }
+    {
+        print;
+    }
+' "${CHANGELOG}" >"${CHANGELOG}.tmp" && mv "${CHANGELOG}.tmp" "${CHANGELOG}"
+
+# Check if there are any existing links at the bottom
+HAS_LINKS=$(awk '/^\[.*\]: / {print; found=1} END { if (!found) exit 1 }' "${CHANGELOG}" 2>/dev/null || echo "")
+
+FIRST_COMMIT=$(git -C "${REPO_PATH}" rev-list --max-parents=0 HEAD)
+
+if [[ -z ${HAS_LINKS} ]]; then
+    # First release, no previous versions
+    # shellcheck disable=SC2129
+    echo "" >>"${CHANGELOG}"
+    echo "[Unreleased]: ${GH_REPO}/compare/${VERSION}...HEAD" >>"${CHANGELOG}"
+    echo "[$VERSION_NO_V]: ${GH_REPO}/compare/${FIRST_COMMIT}...${VERSION}" >>"${CHANGELOG}"
+else
+
+    # Update links
+    awk -v repo="${GH_REPO}" -v ver="${VERSION}" -v ver_no_v="${VERSION_NO_V}" -v prev="${PREV_VERSION}" '
+        BEGIN { unreleased_done=0 }
+        /^\[Unreleased\]: / {
+            unreleased_done=1;
+            print "[Unreleased]: " repo "/compare/" ver "...HEAD";
+            print "[" ver_no_v "]: " repo "/compare/v" prev "..." ver;
+            next;
+        }
+        {
+            print;
+        }
+        END {
+            if (!unreleased_done) {
+                print "[Unreleased]: " repo "/compare/" ver "...HEAD";
+                print "[" ver_no_v "]: " repo "/compare/v" prev "..." ver;
+            }
+        }
+    ' "${CHANGELOG}" >"${CHANGELOG}.tmp" && mv "${CHANGELOG}.tmp" "${CHANGELOG}"
+fi
+
+echo -e "CHANGELOG.md was updated with version ${YELLOW}${VERSION}${NC}"


### PR DESCRIPTION
# Description

This PR adds scripts and documentation for managing electronic projects.

This PR is still work in progress and not considered as complete.

What still needs to be done:
* Document in `doc/development/electronic_projects.md` needs to be improved. It is currently missing exact steps that are needed to create a new Altium project and sync it to GitHub. 
* The main README.md file (in the project root) is expected to be the starting point for anyone. We need to think how we can adjust it, make it fit the constrains that Altium imposes on us. The constraint that I have in mind is the fact that we first need to create a new project on the Alitum and only then push it to the GitHub. The checklist assumes that the GitHub project is always created first. Maybe we can add some sentence at the beginning in the style of `if you are creating an electronic project, first do some other steps and then return to those`?
* Scripts need to be validated on the the Windows machine. I was testing them on my home Windows PC, but right now I had to change the file endings to unix style, I am not sure if the Git Bash handles/cares about that. Also, I want the print statements in the scripts to make sense, so when testing those make sure that they make sense to you.

It the scope of the testing it probably makes sense to create a dummy Altium project and use the scripts on it, to push it to GitHub.

I would be happy if you can come up with a more complete project creation checklist than I did, then we can review it and think how to include it into the existing project.

## After-review steps

- I will merge PR by myself.

[style guidelines]:
  https://github.com/IRNAS/irnas-guidelines-docs/blob/main/docs/developer_guidelines.md
